### PR TITLE
Experimental namespace processing in java

### DIFF
--- a/src/main/java/org/mediawiki/sparql/mwontop/http/MWNamespace.java
+++ b/src/main/java/org/mediawiki/sparql/mwontop/http/MWNamespace.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 MW2SPARQL developers.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mediawiki.sparql.mwontop.http;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class MWNamespace {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SPARQLActions.class);
+    private static Map<String, Map<String, String>> namespaces = new Hashtable<>();
+
+    private static Map<String, String> getNamespaces(String project) {
+        if (!namespaces.containsKey(project)) {
+            Map<String, String> ns = new Hashtable<>();
+            ObjectMapper map = new ObjectMapper();
+            try {
+                JsonNode json = map.readTree(new URL("https://" + project +
+                        "/w/api.php?action=query&meta=siteinfo&siprop=namespaces|namespacealiases&format=json"));
+                for (JsonNode item : json.at("/query/namespaces")) {
+                    if (item.has("canonical")) {
+                        ns.put("ns" + item.get("id").asText() + ":", item.get("canonical").asText() + ":");
+                        ns.put(item.get("canonical").asText() + ":", "ns" + item.get("id").asText() + ":");
+                        if (item.has("*"))
+                            ns.put(item.get("*").asText() + ":", "ns" + item.get("id").asText() + ":");
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.error(e.getMessage(), e);
+            }
+            namespaces.put(project, ns);
+        }
+        return namespaces.get(project);
+    }
+
+    private static Pattern ns_regex = Pattern.compile("//([^/]*)/wiki/([^:]*:)?");
+
+    static String transformNamespace(String input) {
+        Matcher m = ns_regex.matcher(input);
+        StringBuffer buf = new StringBuffer();
+        while (m.find()) {
+            if (m.group(2) != null && getNamespaces(m.group(1)).containsKey(m.group(2))) {
+                m.appendReplacement(buf, input.substring(m.start(), m.start(2)) +
+                        getNamespaces(m.group(1)).get(m.group(2)) + input.substring(m.end(2), m.end()));
+                break;
+            }
+        }
+        m.appendTail(buf);
+        return buf.toString();
+    }
+}

--- a/src/main/java/org/mediawiki/sparql/mwontop/sql/RepositoryFactory.java
+++ b/src/main/java/org/mediawiki/sparql/mwontop/sql/RepositoryFactory.java
@@ -79,7 +79,7 @@ public class RepositoryFactory {
 
     private Repository buildVirtualRepository(MySQLConnectionInformation connectionInformation) throws Exception {
         Map<String, SiteConfig> sitesConfig = loadSitesConfig();
-        setupNamespaceDatabase(sitesConfig);
+//        setupNamespaceDatabase(sitesConfig);
 
         String usualDBName = connectionInformation.getUser() + "__extra";
         Model rdfMapping = new LinkedHashModel();
@@ -167,7 +167,8 @@ public class RepositoryFactory {
             dbMetadata = RDBMetadataExtractionTools.createMetadata(connection);
         }
         for (String siteId : Configuration.getInstance().getAllowedSites()) {
-            addTablesToMetadata(dbMetadata, connectionInformation.withDatabase(connectionInformation.getUser() + "__extra"), Sets.newHashSet(
+//            addTablesToMetadata(dbMetadata, connectionInformation.withDatabase(connectionInformation.getUser() + "__extra"), Sets.newHashSet(
+            addTablesToMetadata(dbMetadata, connectionInformation.withDatabase(siteId + "_p"), Sets.newHashSet(
                     siteId + "_ns_name2id", siteId + "_ns_id2name"
             ));
             addTablesToMetadata(dbMetadata, connectionInformation.withDatabase(siteId + "_p"), TABLES_USED);

--- a/src/main/resources/mapping.ttl
+++ b/src/main/resources/mapping.ttl
@@ -87,12 +87,12 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_id, page_namespace, page_title, page_latest, page_content_model, ns_name FROM {db}.page, {usual_db}.{site_id}_ns_id2name WHERE ns_id = page_namespace AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_id, page_namespace, page_title, page_latest, page_content_model, page_namespace AS ns FROM {db}.page WHERE page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
         rr:class     mw:Page ;
-        rr:template  "{base_url}/wiki/{ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
@@ -161,12 +161,12 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, ns_name FROM {db}.page, {usual_db}.{site_id}_ns_id2name WHERE ns_id = page_namespace AND page_is_redirect = 1 AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS ns FROM {db}.page WHERE page_is_redirect = 1 AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
         rr:class     mw:RedirectPage ;
-        rr:template  "{base_url}/wiki/{ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ]
 ] .
@@ -190,12 +190,12 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, ns_name FROM {db}.page, {usual_db}.{site_id}_ns_id2name WHERE ns_id = page_namespace AND page_is_new = 1 AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS ns FROM {db}.page WHERE page_is_new = 1 AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
         rr:class     mw:NewPage ;
-        rr:template  "{base_url}/wiki/{ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ]
 ] .
@@ -309,7 +309,7 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT rev_id, ns_name, page_title FROM {db}.revision, {db}.page, {usual_db}.{site_id}_ns_id2name WHERE page_id = rev_page AND ns_id = page_namespace AND page_namespace != 0"
+        rr:sqlQuery  "SELECT rev_id, page_namespace AS ns, page_title FROM {db}.revision, {db}.page AS to_ns WHERE page_id = rev_page AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
@@ -321,7 +321,7 @@
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{ns_name}:{page_title}" ;
+            rr:template "{base_url}/wiki/ns{ns}:{page_title}" ;
            rr:termType rr:IRI
        ] ;
        rr:predicate mw:revisionOfPage
@@ -354,7 +354,7 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, pl_title, to_ns.ns_name AS to_ns_name FROM {db}.pagelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = pl_from AND page_namespace = 0 AND to_ns.ns_id = pl_namespace AND pl_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, pl_title, pl_namespace AS ns FROM {db}.pagelinks, {db}.page AS to_ns WHERE page_id = pl_from AND page_namespace = 0 AND pl_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
@@ -365,7 +365,7 @@
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{pl_title}" ;
+            rr:template "{base_url}/wiki/ns{ns}:{pl_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:internalLinkTo
@@ -376,11 +376,11 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, pl_title, from_ns.ns_name AS from_ns_name FROM {db}.pagelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns WHERE page_id = pl_from AND from_ns.ns_id = page_namespace AND pl_namespace = 0 AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, pl_title, page_namespace AS ns FROM {db}.pagelinks, {db}.page WHERE page_id = pl_from AND pl_namespace = 0 AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
@@ -398,18 +398,18 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, pl_title, from_ns.ns_name AS from_ns_name, to_ns.ns_name AS to_ns_name FROM {db}.pagelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = pl_from AND from_ns.ns_id = page_namespace AND to_ns.ns_id = pl_namespace AND page_namespace != 0 AND pl_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, pl_title, page_namespace AS from_ns, pl_namespace AS to_ns FROM {db}.pagelinks, {db}.page WHERE page_id = pl_from AND page_namespace != 0 AND pl_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{from_ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{pl_title}" ;
+            rr:template "{base_url}/wiki/ns{to_ns}:{pl_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:internalLinkTo
@@ -442,7 +442,7 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, to_ns.ns_name AS to_ns_name, tl_title FROM {db}.templatelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = tl_from AND page_namespace = 0 AND to_ns.ns_id = tl_namespace AND tl_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, tl_namespace AS ns, tl_title FROM {db}.templatelinks, {db}.page WHERE page_id = tl_from AND page_namespace = 0 AND tl_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
@@ -453,7 +453,7 @@
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{tl_title}" ;
+            rr:template "{base_url}/wiki/ns{ns}:{tl_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:includesPage
@@ -464,11 +464,11 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, from_ns.ns_name AS from_ns_name, tl_title FROM {db}.templatelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = tl_from AND from_ns.ns_id = page_namespace AND tl_namespace = 0 AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS ns, tl_title FROM {db}.templatelinks, {db}.page WHERE page_id = tl_from AND tl_namespace = 0 AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
@@ -486,18 +486,18 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, from_ns.ns_name AS from_ns_name, to_ns.ns_name AS to_ns_name, tl_title FROM {db}.templatelinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = tl_from AND from_ns.ns_id = page_namespace AND to_ns.ns_id = tl_namespace AND tl_namespace != 0 AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS from_ns, tl_namespace AS to_ns, tl_title FROM {db}.templatelinks, {db}.page WHERE page_id = tl_from AND tl_namespace != 0 AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{from_ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{tl_title}" ;
+            rr:template "{base_url}/wiki/ns{to_ns}:{tl_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:includesPage
@@ -508,7 +508,7 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, to_ns.ns_name AS to_ns_name, cl_to FROM {db}.categorylinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = cl_from AND page_namespace = 0 AND to_ns.ns_id = 14"
+        rr:sqlQuery  "SELECT page_title, 14 AS ns, cl_to FROM {db}.categorylinks, {db}.page WHERE page_id = cl_from AND page_namespace = 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
@@ -519,7 +519,7 @@
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{cl_to}" ;
+            rr:template "{base_url}/wiki/ns{ns}:{cl_to}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:inCategory
@@ -530,18 +530,18 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, from_ns.ns_name AS from_ns_name, to_ns.ns_name AS to_ns_name, cl_to FROM {db}.categorylinks, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = cl_from AND from_ns.ns_id = page_namespace AND page_namespace != 0 AND to_ns.ns_id = 14"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS from_ns, 14 AS to_ns, cl_to FROM {db}.categorylinks, {db}.page WHERE page_id = cl_from AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{from_ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{cl_to}" ;
+            rr:template "{base_url}/wiki/ns{to_ns}:{cl_to}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:inCategory
@@ -574,7 +574,7 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, to_ns.ns_name AS to_ns_name, rd_title FROM {db}.redirect, {db}.page, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = rd_from AND page_namespace = 0 AND to_ns.ns_id = rd_namespace AND rd_interwiki = '' AND rd_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, rd_namespace AS ns, rd_title FROM {db}.redirect, {db}.page WHERE page_id = rd_from AND page_namespace = 0 AND rd_interwiki = '' AND rd_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
@@ -585,7 +585,7 @@
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{rd_title}" ;
+            rr:template "{base_url}/wiki/ns{ns}:{rd_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:redirectsTo
@@ -596,11 +596,11 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, from_ns.ns_name AS from_ns_name, rd_title FROM {db}.redirect, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns WHERE page_id = rd_from AND from_ns.ns_id = page_namespace AND rd_namespace = 0 AND rd_interwiki = ''  AND page_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS ns, rd_title FROM {db}.redirect, {db}.page WHERE page_id = rd_from AND rd_namespace = 0 AND rd_interwiki = ''  AND page_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
@@ -618,18 +618,18 @@
     a rr:TriplesMap ;
     rr:logicalTable [
         a rr:R2RMLView ;
-        rr:sqlQuery  "SELECT page_title, from_ns.ns_name AS from_ns_name, to_ns.ns_name AS to_ns_name, rd_title FROM {db}.redirect, {db}.page, {usual_db}.{site_id}_ns_id2name AS from_ns, {usual_db}.{site_id}_ns_id2name AS to_ns WHERE page_id = rd_from AND from_ns.ns_id = page_namespace AND to_ns.ns_id = rd_namespace AND rd_interwiki = '' AND page_namespace != 0 AND rd_namespace != 0"
+        rr:sqlQuery  "SELECT page_title, page_namespace AS from_ns, rd_namespace AS to_ns, rd_title FROM {db}.redirect, {db}.page WHERE page_id = rd_from AND rd_interwiki = '' AND page_namespace != 0 AND rd_namespace != 0"
     ] ;
     rr:subjectMap [
         a rr:SubjectMap , rr:TermMap ;
-        rr:template  "{base_url}/wiki/{from_ns_name}:{page_title}" ;
+        rr:template  "{base_url}/wiki/ns{from_ns}:{page_title}" ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
         a rr:PredicateObjectMap ;
         rr:objectMap [
             a rr:ObjectMap , rr:TermMap ;
-            rr:template "{base_url}/wiki/{to_ns_name}:{rd_title}" ;
+            rr:template "{base_url}/wiki/ns{to_ns}:{rd_title}" ;
             rr:termType rr:IRI
         ] ;
         rr:predicate mw:redirectsTo


### PR DESCRIPTION
Right now tool cannot work due to change in db replicas (see https://phabricator.wikimedia.org/T188506 for details). In order to get it back to operation, I've made 3 modifications:
1. Comment pieces, related to __extra databases (probably will need additional cleanup here)
2. Modify .ttl so it operates with "fake" namespaces like (e.g. /wiki/ns14:) instead of "real" (/wiki/Category:)
3. Implement java converter from "real" to "fake" namespaces and back based on mediawiki api calls (see comment from Stas Malyshev in phabricator above)

I've tested it locally running simple queries like `select * {<https://en.wikipedia.org/wiki/Category:Burials_by_place> ?predicate ?object}` Running a bit slow, but we can work on perfornance once tool is accessible from WQS via federation.